### PR TITLE
Fix Win32 building errors

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -8,7 +8,7 @@ define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
 $(package)_config_opts=--prefix=$(host_prefix) --openssldir=$(host_prefix)/etc/openssl no-zlib no-shared no-dso
 $(package)_config_opts+=no-krb5 no-camellia no-capieng no-cast no-cms no-dtls1 no-gost no-gmp no-heartbeats no-idea no-jpake no-md2
-$(package)_config_opts+=no-mdc2 no-rc5 no-rdrand no-rfc3779 no-rsax no-sctp no-seed no-sha0 no-static_engine no-whirlpool no-rc2 no-rc4 no-ssl2 no-ssl3
+$(package)_config_opts+=no-mdc2 no-rc5 no-rdrand no-rfc3779 no-rsax no-sctp no-seed no-static_engine no-whirlpool no-rc2 no-rc4 no-ssl2 no-ssl3
 $(package)_config_opts+=$($(package)_cflags) $($(package)_cppflags)
 $(package)_config_opts_linux=-fPIC -Wa,--noexecstack
 $(package)_config_opts_x86_64_linux=linux-x86_64

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -453,7 +453,7 @@ if GLIBC_BACK_COMPAT
 endif
 
 libnamecoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
-libnamecoinconsensus_la_LIBADD = $(LIBSECP256K1)
+libnamecoinconsensus_la_LIBADD = $(LIBSECP256K1) $(BOOST_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) 
 libnamecoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
 libnamecoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 

--- a/src/game/db.cpp
+++ b/src/game/db.cpp
@@ -26,6 +26,8 @@
 #include <vector>
 #include <memory>
 
+#include <boost/thread.hpp>
+
 /* Define prefix for database keys.  We only index by block hash, but still
    need them so we can tell game states apart from the obfuscation key that
    is also in the database.  */


### PR DESCRIPTION
1) We need build openssl with SHA functions so we drop no-sha0
2) We need add SSL and BOOST libs for libnamecoinconsensus_la linking.
3) I got error without 
```
#include <boost/thread.hpp>
```
 at db.cpp
Error:
```
game/db.cpp: In member function ‘void CGameDB::flush(bool)’:
game/db.cpp:236:7: error: ‘interruption_point’ is not a member of ‘boost::this_thread’
       boost::this_thread::interruption_point();
```